### PR TITLE
conduit 0.5

### DIFF
--- a/fb.cabal
+++ b/fb.cabal
@@ -1,5 +1,5 @@
 name:              fb
-version:           0.9.7
+version:           0.10.0
 license:           BSD3
 license-file:      LICENSE
 author:            Felipe Lessa
@@ -61,11 +61,11 @@ library
     , transformers       >= 0.2     && < 0.4
     , transformers-base
     , monad-control
-    , conduit            >= 0.4     && < 0.5
+    , conduit            >= 0.5     && < 0.6
     , http-types
-    , http-conduit       >= 1.4     && < 1.5
+    , http-conduit       >= 1.5     && < 1.6
     , attoparsec         >= 0.10    && < 0.11
-    , attoparsec-conduit >= 0.4     && < 0.5
+    , attoparsec-conduit >= 0.5     && < 0.6
     , aeson              >= 0.5     && < 0.7
     , base64-bytestring  >= 0.1.1   && < 0.2
     , time               >= 1.2     && < 1.5

--- a/src/Facebook/Auth.hs
+++ b/src/Facebook/Auth.hs
@@ -62,7 +62,7 @@ getAppAccessToken =
              tsq creds [("grant_type", "client_credentials")]
     response <- fbhttp req
     lift $
-      H.responseBody response C.$$
+      H.responseBody response C.$$+-
       C.sinkParser (AppAccessToken <$  A.string "access_token="
                                    <*> A.takeByteString)
 

--- a/src/Facebook/Base.hs
+++ b/src/Facebook/Base.hs
@@ -79,10 +79,10 @@ instance ToSimpleQuery (AccessToken anyKind) where
 -- | Converts a plain 'H.Response' coming from 'H.http' into a
 -- JSON value.
 asJson :: (C.MonadThrow m, A.FromJSON a) =>
-          H.Response (C.Source m ByteString)
+          H.Response (C.ResumableSource m ByteString)
        -> FacebookT anyAuth m a
 asJson response = do
-  val <- lift $ H.responseBody response C.$$ C.sinkParser A.json'
+  val <- lift $ H.responseBody response C.$$+- C.sinkParser A.json'
   case A.fromJSON val of
     A.Success r -> return r
     A.Error str ->
@@ -94,9 +94,9 @@ asJson response = do
 
 -- | Converts a plain 'H.Response' into a string 'ByteString'.
 asBS :: (Monad m) =>
-        H.Response (C.Source m ByteString)
+        H.Response (C.ResumableSource m ByteString)
      -> FacebookT anyAuth m ByteString
-asBS response = lift $ H.responseBody response C.$$ fmap B.concat CL.consume
+asBS response = lift $ H.responseBody response C.$$+- fmap B.concat CL.consume
 
 
 -- | An exception that may be thrown by functions on this
@@ -123,7 +123,7 @@ instance E.Exception FacebookException where
 -- meaningful 'FacebookException'@s@.
 fbhttp :: (MonadBaseControl IO m, C.MonadResource m) =>
           H.Request m
-       -> FacebookT anyAuth m (H.Response (C.Source m ByteString))
+       -> FacebookT anyAuth m (H.Response (C.ResumableSource m ByteString))
 fbhttp req = do
   manager <- getManager
   let req' = req { H.checkStatus = \_ _ -> Nothing }


### PR DESCRIPTION
This isn't really a full fix: it still uses the deprecated Ascii type. But it does solve the switch to ResumableSource.
