### PR TITLE
Increase lifted-base dependency upper bound to 0.3

### DIFF
--- a/fb.cabal
+++ b/fb.cabal
@@ -61,7 +61,7 @@ library
     Facebook.TestUsers
   build-depends:
       base               >= 4       && < 5
-    , lifted-base        >= 0.1     && < 0.2
+    , lifted-base        >= 0.1     && < 0.3
     , bytestring         >= 0.9     && < 0.11
     , text               >= 0.11    && < 0.12
     , transformers       >= 0.2     && < 0.4


### PR DESCRIPTION
Yesod-platform-1.1.4 specifies lifted-base==0.2.*, so this is necessary to compile with an up-to-date yesod application. 
