### PR TITLE
Update to monad-control 1.0

### DIFF
--- a/fb.cabal
+++ b/fb.cabal
@@ -72,7 +72,7 @@ library
     , text                 >= 0.11    && < 1.3
     , transformers         >= 0.2     && < 0.5
     , transformers-base
-    , monad-control
+    , monad-control        == 1.0.*
     , resourcet
     , data-default
     , http-types


### PR DESCRIPTION
Straightforward patch to allow [`monad-control`](http://hackage.haskell.org/package/monad-control) 1.0.