### PR TITLE
Update to latest stack version and fix warnings.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,9 +37,9 @@ matrix:
   # - env: BUILD=cabal GHCVER=7.6.3 CABALVER=1.16 HAPPYVER=1.19.5 ALEXVER=3.1.7
   #   compiler: ": #GHC 7.6.3"
   #   addons: {apt: {packages: [cabal-install-1.16,ghc-7.6.3,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
-  - env: BUILD=cabal GHCVER=7.8.4 CABALVER=1.18 HAPPYVER=1.19.5 ALEXVER=3.1.7
-    compiler: ": #GHC 7.8.4"
-    addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
+  # - env: BUILD=cabal GHCVER=7.8.4 CABALVER=1.18 HAPPYVER=1.19.5 ALEXVER=3.1.7
+  #   compiler: ": #GHC 7.8.4"
+  #   addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
   - env: BUILD=cabal GHCVER=7.10.3 CABALVER=1.22 HAPPYVER=1.19.5 ALEXVER=3.1.7
     compiler: ": #GHC 7.10.3"
     addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
@@ -59,9 +59,9 @@ matrix:
     compiler: ": #stack default"
     addons: {apt: {packages: [ghc-7.10.3], sources: [hvr-ghc]}}
 
-  - env: BUILD=stack ARGS="--resolver lts-2"
-    compiler: ": #stack 7.8.4"
-    addons: {apt: {packages: [ghc-7.8.4], sources: [hvr-ghc]}}
+  # - env: BUILD=stack ARGS="--resolver lts-2"
+  #   compiler: ": #stack 7.8.4"
+  #   addons: {apt: {packages: [ghc-7.8.4], sources: [hvr-ghc]}}
 
   - env: BUILD=stack ARGS="--resolver lts-3"
     compiler: ": #stack 7.10.2"
@@ -85,9 +85,9 @@ matrix:
     compiler: ": #stack default osx"
     os: osx
 
-  - env: BUILD=stack ARGS="--resolver lts-2"
-    compiler: ": #stack 7.8.4 osx"
-    os: osx
+  # - env: BUILD=stack ARGS="--resolver lts-2"
+  #   compiler: ": #stack 7.8.4 osx"
+  #   os: osx
 
   - env: BUILD=stack ARGS="--resolver lts-3"
     compiler: ": #stack 7.10.2 osx"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,186 @@
+# Copy these contents into the root directory of your Github project in a file
+# named .travis.yml
+
+# Use new container infrastructure to enable caching
+sudo: false
+
+# Choose a lightweight base image; we provide our own build tools.
+language: c
+
+# Caching so the next build will be fast too.
+cache:
+  directories:
+  - $HOME/.ghc
+  - $HOME/.cabal
+  - $HOME/.stack
+
+# The different configurations we want to test. We have BUILD=cabal which uses
+# cabal-install, and BUILD=stack which uses Stack. More documentation on each
+# of those below.
+#
+# We set the compiler values here to tell Travis to use a different
+# cache file per set of arguments.
+#
+# If you need to have different apt packages for each combination in the
+# matrix, you can use a line such as:
+#     addons: {apt: {packages: [libfcgi-dev,libgmp-dev]}}
+matrix:
+  include:
+  # We grab the appropriate GHC and cabal-install versions from hvr's PPA. See:
+  # https://github.com/hvr/multi-ghc-travis
+  #- env: BUILD=cabal GHCVER=7.0.4 CABALVER=1.16 HAPPYVER=1.19.5 ALEXVER=3.1.7
+  #  compiler: ": #GHC 7.0.4"
+  #  addons: {apt: {packages: [cabal-install-1.16,ghc-7.0.4,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
+  #- env: BUILD=cabal GHCVER=7.2.2 CABALVER=1.16 HAPPYVER=1.19.5 ALEXVER=3.1.7
+  #  compiler: ": #GHC 7.2.2"
+  #  addons: {apt: {packages: [cabal-install-1.16,ghc-7.2.2,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
+  #- env: BUILD=cabal GHCVER=7.4.2 CABALVER=1.16 HAPPYVER=1.19.5 ALEXVER=3.1.7
+  #  compiler: ": #GHC 7.4.2"
+  #  addons: {apt: {packages: [cabal-install-1.16,ghc-7.4.2,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
+  # - env: BUILD=cabal GHCVER=7.6.3 CABALVER=1.16 HAPPYVER=1.19.5 ALEXVER=3.1.7
+  #   compiler: ": #GHC 7.6.3"
+  #   addons: {apt: {packages: [cabal-install-1.16,ghc-7.6.3,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
+  - env: BUILD=cabal GHCVER=7.8.4 CABALVER=1.18 HAPPYVER=1.19.5 ALEXVER=3.1.7
+    compiler: ": #GHC 7.8.4"
+    addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
+  - env: BUILD=cabal GHCVER=7.10.3 CABALVER=1.22 HAPPYVER=1.19.5 ALEXVER=3.1.7
+    compiler: ": #GHC 7.10.3"
+    addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
+  - env: BUILD=cabal GHCVER=8.0.1 CABALVER=1.24 HAPPYVER=1.19.5 ALEXVER=3.1.7
+    compiler: ": #GHC 8.0.1"
+    addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.1,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
+
+  # Build with the newest GHC and cabal-install. This is an accepted failure,
+  # see below.
+  - env: BUILD=cabal GHCVER=head  CABALVER=head HAPPYVER=1.19.5 ALEXVER=3.1.7
+    compiler: ": #GHC HEAD"
+    addons: {apt: {packages: [cabal-install-head,ghc-head,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
+
+  # The Stack builds. We can pass in arbitrary Stack arguments via the ARGS
+  # variable, such as using --stack-yaml to point to a different file.
+  - env: BUILD=stack ARGS=""
+    compiler: ": #stack default"
+    addons: {apt: {packages: [ghc-7.10.3], sources: [hvr-ghc]}}
+
+  - env: BUILD=stack ARGS="--resolver lts-2"
+    compiler: ": #stack 7.8.4"
+    addons: {apt: {packages: [ghc-7.8.4], sources: [hvr-ghc]}}
+
+  - env: BUILD=stack ARGS="--resolver lts-3"
+    compiler: ": #stack 7.10.2"
+    addons: {apt: {packages: [ghc-7.10.2], sources: [hvr-ghc]}}
+
+  - env: BUILD=stack ARGS="--resolver lts-5"
+    compiler: ": #stack 7.10.3 (lts-5)"
+    addons: {apt: {packages: [ghc-7.10.3], sources: [hvr-ghc]}}
+
+  - env: BUILD=stack ARGS="--resolver lts-6"
+    compiler: ": #stack 7.10.3 (lts-6)"
+    addons: {apt: {packages: [ghc-7.10.3], sources: [hvr-ghc]}}
+
+  # Nightly builds are allowed to fail
+  - env: BUILD=stack ARGS="--resolver nightly"
+    compiler: ": #stack nightly"
+    addons: {apt: {packages: [libgmp,libgmp-dev]}}
+
+  # Build on OS X in addition to Linux
+  - env: BUILD=stack ARGS=""
+    compiler: ": #stack default osx"
+    os: osx
+
+  - env: BUILD=stack ARGS="--resolver lts-2"
+    compiler: ": #stack 7.8.4 osx"
+    os: osx
+
+  - env: BUILD=stack ARGS="--resolver lts-3"
+    compiler: ": #stack 7.10.2 osx"
+    os: osx
+
+  - env: BUILD=stack ARGS="--resolver lts-5"
+    compiler: ": #stack 7.10.3 (lts-5) osx"
+    os: osx
+
+  - env: BUILD=stack ARGS="--resolver lts-6"
+    compiler: ": #stack 7.10.3 (lts-6) osx"
+    os: osx
+
+  - env: BUILD=stack ARGS="--resolver nightly"
+    compiler: ": #stack nightly osx"
+    os: osx
+
+  allow_failures:
+  - env: BUILD=cabal GHCVER=head  CABALVER=head HAPPYVER=1.19.5 ALEXVER=3.1.7
+  - env: BUILD=stack ARGS="--resolver nightly"
+
+before_install:
+# Using compiler above sets CC to an invalid value, so unset it
+- unset CC
+
+# We want to always allow newer versions of packages when building on GHC HEAD
+- CABALARGS=""
+- if [ "x$GHCVER" = "xhead" ]; then CABALARGS=--allow-newer; fi
+
+# Download and unpack the stack executable
+- export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$HOME/.local/bin:/opt/alex/$ALEXVER/bin:/opt/happy/$HAPPYVER/bin:$HOME/.cabal/bin:$PATH
+- mkdir -p ~/.local/bin
+- |
+  if [ `uname` = "Darwin" ]
+  then
+    travis_retry curl --insecure -L https://www.stackage.org/stack/osx-x86_64 | tar xz --strip-components=1 --include '*/stack' -C ~/.local/bin
+  else
+    travis_retry curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
+  fi
+
+  # Use the more reliable S3 mirror of Hackage
+  mkdir -p $HOME/.cabal
+  echo 'remote-repo: hackage.haskell.org:http://hackage.fpcomplete.com/' > $HOME/.cabal/config
+  echo 'remote-repo-cache: $HOME/.cabal/packages' >> $HOME/.cabal/config
+
+  if [ "$CABALVER" != "1.16" ]
+  then
+    echo 'jobs: $ncpus' >> $HOME/.cabal/config
+  fi
+
+# Get the list of packages from the stack.yaml file
+- PACKAGES=$(stack --install-ghc query locals | grep '^ *path' | sed 's@^ *path:@@')
+
+install:
+- echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"
+- if [ -f configure.ac ]; then autoreconf -i; fi
+- |
+  set -ex
+  case "$BUILD" in
+    stack)
+      stack --no-terminal --install-ghc $ARGS test --bench --only-dependencies
+      ;;
+    cabal)
+      cabal --version
+      travis_retry cabal update
+      cabal install --only-dependencies --enable-tests --enable-benchmarks --force-reinstalls --ghc-options=-O0 --reorder-goals --max-backjumps=-1 $CABALARGS $PACKAGES
+      ;;
+  esac
+  set +ex
+
+script:
+- |
+  set -ex
+  case "$BUILD" in
+    stack)
+      stack --no-terminal $ARGS test --bench --no-run-benchmarks --haddock --no-haddock-deps
+      ;;
+    cabal)
+      cabal install --enable-tests --enable-benchmarks --force-reinstalls --ghc-options=-O0 --reorder-goals --max-backjumps=-1 $CABALARGS $PACKAGES
+
+      ORIGDIR=$(pwd)
+      for dir in $PACKAGES
+      do
+        cd $dir
+        cabal check || [ "$CABALVER" == "1.16" ]
+        cabal sdist
+        SRC_TGZ=$(cabal info . | awk '{print $2;exit}').tar.gz && \
+          (cd dist && cabal install --force-reinstalls "$SRC_TGZ")
+        cd $ORIGDIR
+      done
+      ;;
+  esac
+  set +ex

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,3 @@
-# Copy these contents into the root directory of your Github project in a file
-# named .travis.yml
-
 # Use new container infrastructure to enable caching
 sudo: false
 
@@ -151,12 +148,14 @@ install:
   set -ex
   case "$BUILD" in
     stack)
-      stack --no-terminal --install-ghc $ARGS test --bench --only-dependencies
+      # stack --no-terminal --install-ghc $ARGS test --bench --only-dependencies
+      stack --no-terminal --install-ghc $ARGS build --bench --only-dependencies
       ;;
     cabal)
       cabal --version
       travis_retry cabal update
-      cabal install --only-dependencies --enable-tests --enable-benchmarks --force-reinstalls --ghc-options=-O0 --reorder-goals --max-backjumps=-1 $CABALARGS $PACKAGES
+      # cabal install --only-dependencies --enable-tests --enable-benchmarks --force-reinstalls --ghc-options=-O0 --reorder-goals --max-backjumps=-1 $CABALARGS $PACKAGES
+      cabal install --only-dependencies --enable-benchmarks --force-reinstalls --ghc-options=-O0 --reorder-goals --max-backjumps=-1 $CABALARGS $PACKAGES
       ;;
   esac
   set +ex
@@ -166,10 +165,12 @@ script:
   set -ex
   case "$BUILD" in
     stack)
-      stack --no-terminal $ARGS test --bench --no-run-benchmarks --haddock --no-haddock-deps
+      # stack --no-terminal $ARGS test --bench --no-run-benchmarks --haddock --no-haddock-deps
+      stack --no-terminal $ARGS build --bench --no-run-benchmarks --haddock --no-haddock-deps
       ;;
     cabal)
-      cabal install --enable-tests --enable-benchmarks --force-reinstalls --ghc-options=-O0 --reorder-goals --max-backjumps=-1 $CABALARGS $PACKAGES
+      # cabal install --enable-tests --enable-benchmarks --force-reinstalls --ghc-options=-O0 --reorder-goals --max-backjumps=-1 $CABALARGS $PACKAGES
+      cabal install --enable-benchmarks --force-reinstalls --ghc-options=-O0 --reorder-goals --max-backjumps=-1 $CABALARGS $PACKAGES
 
       ORIGDIR=$(pwd)
       for dir in $PACKAGES

--- a/README.md
+++ b/README.md
@@ -1,0 +1,4 @@
+
+# fb [![Hackage](https://img.shields.io/hackage/v/fb.svg?style=flat)](https://hackage.haskell.org/package/fb) [![Build Status](https://travis-ci.org/prowdsponsor/fb.png)](https://travis-ci.org/prowdsponsor/fb)
+
+Haskell library for accessing Facebook's API.

--- a/fb.cabal
+++ b/fb.cabal
@@ -129,7 +129,7 @@ test-suite runtests
     , data-default
     , HUnit
     , QuickCheck
-    , hspec >= 1.9 && < 1.12
+    , hspec >= 1.9
     , fb
   extensions:
     TypeFamilies

--- a/fb.cabal
+++ b/fb.cabal
@@ -68,7 +68,7 @@ library
     Facebook.Types
   build-depends:
       base                 >= 4       && < 5
-    , aeson                >= 0.5
+    , aeson                >= 0.7
     , attoparsec           >= 0.10.4  && < 0.14
     , base16-bytestring    >= 0.1
     , base64-bytestring    >= 0.1.1

--- a/fb.cabal
+++ b/fb.cabal
@@ -27,6 +27,7 @@ description:
   (<https://github.com/prowdsponsor/fb/issues>).
 
 extra-source-files:
+  README.md
   tests/Main.hs
   tests/tryIt.hs
   example.hs

--- a/fb.cabal
+++ b/fb.cabal
@@ -50,45 +50,46 @@ library
   exposed-modules:
     Facebook
   other-modules:
-    Facebook.Types
-    Facebook.Monad
-    Facebook.Base
     Facebook.Auth
-    Facebook.Pager
-    Facebook.Graph
-    Facebook.Object.Action
-    Facebook.Object.FriendList
-    Facebook.Object.Checkin
-    Facebook.Object.User
-    Facebook.Object.Page
-    Facebook.Object.Order
-    Facebook.RealTime
+    Facebook.Base
     Facebook.FQL
+    Facebook.Graph
+    Facebook.Monad
+    Facebook.Object.Action
+    Facebook.Object.Checkin
+    Facebook.Object.FriendList
+    Facebook.Object.Order
+    Facebook.Object.Page
+    Facebook.Object.User
+    Facebook.Pager
+    Facebook.RealTime
     Facebook.TestUsers
+    Facebook.Types
   build-depends:
       base                 >= 4       && < 5
-    , lifted-base          >= 0.1     && < 0.3
-    , bytestring           >= 0.9     && < 0.11
-    , text                 >= 0.11    && < 1.3
-    , transformers         >= 0.2     && < 0.6
-    , transformers-base
-    , monad-control
-    , resourcet
-    , data-default
-    , http-types
-    , http-conduit         >= 2.0     && < 2.2
-    , attoparsec           >= 0.10.4  && < 0.14
-    , unordered-containers
     , aeson                >= 0.5
+    , attoparsec           >= 0.10.4  && < 0.14
     , base16-bytestring    >= 0.1
     , base64-bytestring    >= 0.1.1
-    , time                 >= 1.2     && < 1.7
-    , old-locale
+    , bytestring           >= 0.9     && < 0.11
     , cereal               >= 0.3     && < 0.6
     , crypto-api           >= 0.11    && < 0.14
     , cryptohash           >= 0.7
     , cryptohash-cryptoapi == 0.1.*
+    , data-default
+    , exceptions
+    , http-conduit         >= 2.0     && < 2.2
+    , http-types
+    , lifted-base          >= 0.1     && < 0.3
+    , monad-control
     , monad-logger         >= 0.3
+    , old-locale
+    , resourcet
+    , text                 >= 0.11    && < 1.3
+    , time                 >= 1.2     && < 1.7
+    , transformers         >= 0.2     && < 0.6
+    , transformers-base
+    , unordered-containers
   if flag(conduit11)
     build-depends:
         conduit              >= 1.1   && < 1.3
@@ -100,14 +101,14 @@ library
   extensions:
     DeriveDataTypeable
     EmptyDataDecls
-    OverloadedStrings
-    GADTs
-    StandaloneDeriving
-    ScopedTypeVariables
-    GeneralizedNewtypeDeriving
-    TypeFamilies
     FlexibleInstances
+    GADTs
+    GeneralizedNewtypeDeriving
     MultiParamTypeClasses
+    OverloadedStrings
+    ScopedTypeVariables
+    StandaloneDeriving
+    TypeFamilies
   if flag(debug)
     cpp-options: -DDEBUG
 

--- a/src/Facebook/Auth.hs
+++ b/src/Facebook/Auth.hs
@@ -15,7 +15,6 @@ module Facebook.Auth
     , DebugToken(..)
     ) where
 
-import Control.Applicative
 import Control.Monad (guard, join, liftM, mzero)
 import Control.Monad.IO.Class (MonadIO(liftIO))
 import Control.Monad.Trans.Control (MonadBaseControl)
@@ -35,7 +34,7 @@ import qualified Control.Exception.Lifted as E
 import qualified Control.Monad.Trans.Resource as R
 import qualified Data.Aeson as AE
 import qualified Data.Aeson.Types as AE
-import qualified Data.Attoparsec.Char8 as AB
+import qualified Data.Attoparsec.ByteString.Char8 as AB
 import qualified Data.Attoparsec.Text as A
 import qualified Data.ByteString as B
 import qualified Data.ByteString.Base64.URL as Base64URL

--- a/src/Facebook/Base.hs
+++ b/src/Facebook/Base.hs
@@ -24,7 +24,7 @@ import Control.Monad.Trans.Class (MonadTrans)
 import Control.Monad.Trans.Control (MonadBaseControl)
 import qualified Control.Monad.Trans.Resource as R
 import qualified Data.Aeson as A
-import qualified Data.Attoparsec.Char8 as AT
+import qualified Data.Attoparsec.ByteString.Char8 as AT
 import qualified Data.ByteString as B
 import qualified Data.Conduit as C
 import qualified Data.Conduit.Attoparsec as C

--- a/src/Facebook/FQL.hs
+++ b/src/Facebook/FQL.hs
@@ -6,9 +6,7 @@ module Facebook.FQL
     , FQLObject(..)
     ) where
 
-import Control.Applicative((<$>))
 import Control.Monad.Trans.Control (MonadBaseControl)
-import Data.Monoid (mempty)
 import Data.Text (Text)
 import Data.Time (UTCTime)
 import Data.Time.Clock.POSIX (posixSecondsToUTCTime)

--- a/src/Facebook/Graph.hs
+++ b/src/Facebook/Graph.hs
@@ -12,8 +12,6 @@ module Facebook.Graph
     , Tag(..)
     ) where
 
-
-import Control.Applicative
 import Control.Monad (mzero)
 import Control.Monad.Trans.Control (MonadBaseControl)
 import Data.ByteString.Char8 (ByteString)
@@ -21,7 +19,7 @@ import Data.Int (Int8, Int16, Int32, Int64)
 import Data.List (intersperse)
 import Data.Text (Text)
 import Data.Typeable (Typeable)
-import Data.Word (Word, Word8, Word16, Word32, Word64)
+import Data.Word (Word8, Word16, Word32, Word64)
 #if MIN_VERSION_time(1,5,0)
 import Data.Time (defaultTimeLocale)
 #else
@@ -30,7 +28,7 @@ import System.Locale (defaultTimeLocale)
 
 import qualified Control.Monad.Trans.Resource as R
 import qualified Data.Aeson as A
-import qualified Data.Aeson.Encode as AE (fromValue)
+import qualified Data.Aeson.Encode as AE (encodeToTextBuilder)
 import qualified Data.ByteString.Char8 as B
 import qualified Data.Text.Encoding as TE
 import qualified Data.Text.Lazy as TL
@@ -258,7 +256,7 @@ instance SimpleType GeoCoordinates where
   encodeFbParam c =
     let obj  = A.object [ "latitude"  A..= latitude  c
                         , "longitude" A..= longitude c]
-        toBS = TE.encodeUtf8 . TL.toStrict . TLB.toLazyText . AE.fromValue
+        toBS = TE.encodeUtf8 . TL.toStrict . TLB.toLazyText . AE.encodeToTextBuilder
     in toBS obj
 
 

--- a/src/Facebook/Monad.hs
+++ b/src/Facebook/Monad.hs
@@ -27,7 +27,7 @@ module Facebook.Monad
     , lift
     ) where
 
-import Control.Applicative (Applicative, Alternative)
+import Control.Applicative (Alternative)
 import Control.Monad (MonadPlus, liftM)
 import Control.Monad.Base (MonadBase(..))
 import Control.Monad.Fix (MonadFix)

--- a/src/Facebook/Object/Checkin.hs
+++ b/src/Facebook/Object/Checkin.hs
@@ -6,7 +6,6 @@ module Facebook.Object.Checkin
    , createCheckin
    ) where
 
-import Control.Applicative
 import Control.Monad (mzero)
 import Control.Monad.Trans.Control (MonadBaseControl)
 import Data.Aeson ((.:), (.:?))

--- a/src/Facebook/Object/FriendList.hs
+++ b/src/Facebook/Object/FriendList.hs
@@ -6,7 +6,6 @@ module Facebook.Object.FriendList
     , getFriendListMembers
     ) where
 
-import Control.Applicative
 import Control.Monad (mzero)
 import Control.Monad.Trans.Control (MonadBaseControl)
 import Data.Aeson ((.:))

--- a/src/Facebook/Object/Order.hs
+++ b/src/Facebook/Object/Order.hs
@@ -7,7 +7,6 @@ module Facebook.Object.Order
     , getOrder
     ) where
 
-import Control.Applicative
 import Control.Monad (mzero)
 import Control.Monad.Trans.Control (MonadBaseControl)
 import Data.Text (Text)

--- a/src/Facebook/Object/Page.hs
+++ b/src/Facebook/Object/Page.hs
@@ -8,7 +8,6 @@ module Facebook.Object.Page
        , searchPages
        ) where
 
-import Control.Applicative
 import Control.Monad (mzero)
 import Control.Monad.Trans.Control (MonadBaseControl)
 import Data.Aeson ((.:), (.:?))

--- a/src/Facebook/Object/User.hs
+++ b/src/Facebook/Object/User.hs
@@ -9,7 +9,6 @@ module Facebook.Object.User
     , getUserFriends
     ) where
 
-import Control.Applicative
 import Control.Monad (mzero)
 import Control.Monad.Trans.Control (MonadBaseControl)
 import Data.Aeson ((.:), (.:?))

--- a/src/Facebook/RealTime.hs
+++ b/src/Facebook/RealTime.hs
@@ -13,7 +13,6 @@ module Facebook.RealTime
     , RealTimeUpdateNotificationUserEntry(..)
     ) where
 
-import Control.Applicative ((<$>), (<*>))
 import Control.Monad.Trans.Control (MonadBaseControl)
 import Control.Monad (liftM, mzero, void)
 import Crypto.Hash.CryptoAPI (SHA1)

--- a/src/Facebook/TestUsers.hs
+++ b/src/Facebook/TestUsers.hs
@@ -11,7 +11,6 @@ module Facebook.TestUsers
     ) where
 
 
-import Control.Applicative ((<$>), (<*>))
 import Control.Monad (unless, mzero)
 import Control.Monad.Trans.Control (MonadBaseControl)
 import Data.Default

--- a/src/Facebook/Types.hs
+++ b/src/Facebook/Types.hs
@@ -19,16 +19,14 @@ module Facebook.Types
     , FbUTCTime(..)
     ) where
 
-import Control.Applicative ((<$>), (<*>), pure)
 import Control.Monad (mzero)
 import Data.ByteString (ByteString)
 import Data.Int (Int64)
-import Data.Monoid (Monoid, mappend)
 import Data.String (IsString)
 import Data.Text (Text)
-import Data.Time (UTCTime, parseTime)
+import Data.Time (UTCTime, parseTimeM)
 import Data.Time.Clock.POSIX (posixSecondsToUTCTime)
-import Data.Typeable (Typeable, Typeable1)
+import Data.Typeable (Typeable)
 #if MIN_VERSION_time(1,5,0)
 import Data.Time (defaultTimeLocale)
 #else
@@ -93,7 +91,7 @@ type AppAccessToken = AccessToken AppKind
 deriving instance Eq   (AccessToken kind)
 deriving instance Ord  (AccessToken kind)
 deriving instance Show (AccessToken kind)
-deriving instance Typeable1 AccessToken
+deriving instance Typeable AccessToken
 
 
 -- | The access token data that is passed to Facebook's API
@@ -222,7 +220,7 @@ newtype FbUTCTime = FbUTCTime { unFbUTCTime :: UTCTime }
 
 instance A.FromJSON FbUTCTime where
   parseJSON (A.String t) =
-    case parseTime defaultTimeLocale "%FT%T%z" (T.unpack t) of
+    case parseTimeM True defaultTimeLocale "%FT%T%z" (T.unpack t) of
       Just d -> return (FbUTCTime d)
       _      -> fail $ "could not parse FbUTCTime string " ++ show t
   parseJSON (A.Number n) =

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,6 @@
 # For more information, see: https://github.com/commercialhaskell/stack/blob/release/doc/yaml_configuration.md
 
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
-# resolver: lts-6.9
 resolver: lts-6.11
 
 # Local packages, usually specified by relative directory name

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,15 +1,15 @@
 # For more information, see: https://github.com/commercialhaskell/stack/blob/release/doc/yaml_configuration.md
 
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
-resolver: lts-3.20
+# resolver: lts-6.9
+resolver: lts-6.11
 
 # Local packages, usually specified by relative directory name
 packages:
 - '.'
 
 # Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
-extra-deps:
-  - attoparsec-conduit-1.1.0
+extra-deps: []
 
 # Override default flag values for local packages and extra-deps
 flags: {}


### PR DESCRIPTION
This PR includes a couple different changes:
- Updates the stack version from 3.20 to 6.11.
- Removes any support for ghc versions less than 7.10.
  - It looks like there was originally support for 7.8, but `origin/master` currently does not compile on 7.8, so everything about 7.8 was removed.
- Gets rid of all compiler warnings.
- Adds a `.travis.yml`.  You can checkout the tests [here](https://travis-ci.org/cdepillabout/fb).  It's currently being tested on a couple recent versions of stackage, along with raw cabal.  Everything is passing (other than GHC HEAD).
  - The `.travis.yml` was adapted from [here](https://docs.haskellstack.org/en/stable/GUIDE/#travis-with-caching).
- Adds a simple `README.md`.
